### PR TITLE
Add event typings for declaration merging

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare namespace EventEmitter {
   }
 
   export interface EventEmitterStatic {
-    new(): EventEmitter;
+    new<EventTypes extends string | symbol = string | symbol>(): EventEmitter<EventTypes>;
   }
 
   export const EventEmitter: EventEmitterStatic;


### PR DESCRIPTION
I wasn't able to build with the event typings locally. When I added declarations for the namespace-merged constructor definition things worked great, so I think this is all that's needed.

I also created a test file (`src/custom-event-types.ts`) in my project [over here](https://github.com/delta62/ee3-ts-example/tree/event-types) if you want to fiddle around with it yourself :slightly_smiling_face: 